### PR TITLE
[PR] Support to post-process on GPU with MetalCamera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 This project is Object Segmentation on iOS with Core ML.<br>If you are interested in iOS + Machine Learning, visit [here](https://github.com/motlabs/iOS-Proejcts-with-ML-Models) you can see various DEMOs.<br>
 
-| Screenshot 1               | Screenshot 2               | Screenshot 3               | Screenshot 4               |
-| -------------------------- | -------------------------- | -------------------------- | -------------------------- |
-| ![](resource/IMG_3632.PNG) | ![](resource/IMG_3633.PNG) | ![](resource/IMG_3634.PNG) | ![](resource/IMG_3635.PNG) |
+| DEMO                                                         | Screenshot 1                                  | Screenshot 2                                  | Screenshot 3                                  |
+| ------------------------------------------------------------ | --------------------------------------------- | --------------------------------------------- | --------------------------------------------- |
+| <img src="https://user-images.githubusercontent.com/37643248/99242802-167ad280-2843-11eb-959a-5fe3b169d8f0.gif" width=240px> | <img src="resource/IMG_3633.PNG" width=240px> | <img src="resource/IMG_3632.PNG" width=240px> | <img src="resource/IMG_3635.PNG" width=240px> |
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ⏲SemanticSegmentation-CoreML
+# SemanticSegmentation-CoreML
 
 ![platform-ios](https://img.shields.io/badge/platform-ios-lightgrey.svg)
 ![swift-version](https://img.shields.io/badge/swift-5.0-red.svg)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SemanticSegmentation-CoreML
+# ⏲SemanticSegmentation-CoreML
 
 ![platform-ios](https://img.shields.io/badge/platform-ios-lightgrey.svg)
 ![swift-version](https://img.shields.io/badge/swift-5.0-red.svg)
@@ -6,8 +6,8 @@
 
 This project is Object Segmentation on iOS with Core ML.<br>If you are interested in iOS + Machine Learning, visit [here](https://github.com/motlabs/iOS-Proejcts-with-ML-Models) you can see various DEMOs.<br>
 
-| Screenshot 1 | Screenshot 2 | Screenshot 3 | Screenshot 4 |
-| ------------ | ------------ | ------------ | ------------ |
+| Screenshot 1               | Screenshot 2               | Screenshot 3               | Screenshot 4               |
+| -------------------------- | -------------------------- | -------------------------- | -------------------------- |
 | ![](resource/IMG_3632.PNG) | ![](resource/IMG_3633.PNG) | ![](resource/IMG_3634.PNG) | ![](resource/IMG_3635.PNG) |
 
 ## How it works
@@ -28,27 +28,35 @@ Download model from [apple's model page](https://developer.apple.com/machine-lea
 
 ### Matadata
 
-|            | input node    | output node    |   size   |
-| :--------: | :-----------: | :------------: | :------: |
-| DeepLabV3     | `[1, 513, 513, 3]`<br>name: `image` | `[513, 513]`<br>name: `semanticPredictions` | 8.6 MB |
-| DeepLabV3FP16 | `[1, 513, 513, 3]`<br>name: `image` | `[513, 513]`<br>name: `semanticPredictions` | 4.3 MB |
+|                  |             input node              |                 output node                 |  size  |
+| :--------------: | :---------------------------------: | :-----------------------------------------: | :----: |
+|    DeepLabV3     | `[1, 513, 513, 3]`<br>name: `image` | `[513, 513]`<br>name: `semanticPredictions` | 8.6 MB |
+|  DeepLabV3FP16   | `[1, 513, 513, 3]`<br>name: `image` | `[513, 513]`<br>name: `semanticPredictions` | 4.3 MB |
 | DeepLabV3Int8LUT | `[1, 513, 513, 3]`<br>name: `image` | `[513, 513]`<br>name: `semanticPredictions` | 2.3 MB |
 
 ### Inference Time
 
-| Device        | Inference Time | Total Time |
-| ------------- | :------: | :-----: |
-| iPhone XS Max | **133 ms** | 434 ms |
-| iPhone XS     | 135 ms | 411 ms |
-| iPhone XR     | 133 ms | **402 ms** |
-| iPhone X      | 178 ms | 509 ms |
-| iPhone 8+     | 180 ms | 563 ms |
-| iPhone 8      | 189 ms | 529 ms |
-| iPhone 7+     | 240 ms | 667 ms |
-| iPhone 7      | 247 ms | 688 ms |
-| iPhone 6S +   | 309 ms | 1015 ms |
-| iPhone 6+     | 1888 ms | 2753 ms |
+| Device            | Inference Time | Total Time (GPU) | Total Time (CPU) |
+| ----------------- | :------------: | :--------------: | :--------------: |
+| iPhone 12 Pro     |       ⏲        |        ⏲         |        ⏲         |
+| iPhone 12 Pro Max |       ⏲        |        ⏲         |        ⏲         |
+| iPhone 12         |       ⏲        |        ⏲         |        ⏲         |
+| iPhone 12 Mini    |       ⏲        |        ⏲         |        ⏲         |
+| iPhone 11 Pro     |     39 ms      |      40 ms       |      290 ms      |
+| iPhone 11 Pro Max |   **35 ms**    |    **36 ms**     |    **280 ms**    |
+| iPhone 11         |       ⏲        |        ⏲         |        ⏲         |
+| iPhone SE (2nd)   |       ⏲        |        ⏲         |        ⏲         |
+| iPhone XS Max     |     133 ms     |        ⏲         |      434 ms      |
+| iPhone XS         |     135 ms     |        ⏲         |      411 ms      |
+| iPhone XR         |     133 ms     |        ⏲         |      402 ms      |
+| iPhone X          |     178 ms     |        ⏲         |      509 ms      |
+| iPhone 8+         |     180 ms     |        ⏲         |      563 ms      |
+| iPhone 8          |     189 ms     |        ⏲         |      529 ms      |
+| iPhone 7+         |     240 ms     |        ⏲         |      667 ms      |
+| iPhone 7          |     247 ms     |        ⏲         |      688 ms      |
+| iPhone 6S +       |     309 ms     |        ⏲         |     1015 ms      |
 
+⏲: need to measure
 
 ## See also
 

--- a/SemanticSegmentation-CoreML.xcodeproj/project.pbxproj
+++ b/SemanticSegmentation-CoreML.xcodeproj/project.pbxproj
@@ -20,6 +20,15 @@
 		71BBE06222E3400E00E74F11 /* VideoCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BBE06022E3400E00E74F11 /* VideoCapture.swift */; };
 		71BBE06322E3400E00E74F11 /* Measure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BBE06122E3400E00E74F11 /* Measure.swift */; };
 		71BBE06722E3446300E74F11 /* SegmentationResultMLMultiArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71BBE06622E3446300E74F11 /* SegmentationResultMLMultiArray.swift */; };
+		C4BB0D92256195AE00354C08 /* MetalRenderingDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BB0D91256195AE00354C08 /* MetalRenderingDevice.swift */; };
+		C4BB0D96256195F800354C08 /* Maths.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BB0D95256195F800354C08 /* Maths.swift */; };
+		C4BB0D99256196A300354C08 /* CameraTextureGenerater.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BB0D98256196A300354C08 /* CameraTextureGenerater.swift */; };
+		C4BB0D9C256196ED00354C08 /* Texture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BB0D9B256196ED00354C08 /* Texture.swift */; };
+		C4BB0DA02561983C00354C08 /* SegmentationTextureGenerater.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BB0D9F2561983C00354C08 /* SegmentationTextureGenerater.swift */; };
+		C4BB0DA3256199B200354C08 /* OverlayingTexturesGenerater.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BB0DA2256199B200354C08 /* OverlayingTexturesGenerater.swift */; };
+		C4BB0DA625619AA400354C08 /* MetalVideoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BB0DA525619AA400354C08 /* MetalVideoView.swift */; };
+		C4BB0DA925619C0400354C08 /* LiveMetalCameraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4BB0DA825619C0400354C08 /* LiveMetalCameraViewController.swift */; };
+		C4BB0DB52561A47900354C08 /* Shaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = C4BB0DB42561A47900354C08 /* Shaders.metal */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +47,15 @@
 		71BBE06022E3400E00E74F11 /* VideoCapture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoCapture.swift; sourceTree = "<group>"; };
 		71BBE06122E3400E00E74F11 /* Measure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Measure.swift; sourceTree = "<group>"; };
 		71BBE06622E3446300E74F11 /* SegmentationResultMLMultiArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentationResultMLMultiArray.swift; sourceTree = "<group>"; };
+		C4BB0D91256195AE00354C08 /* MetalRenderingDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalRenderingDevice.swift; sourceTree = "<group>"; };
+		C4BB0D95256195F800354C08 /* Maths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Maths.swift; sourceTree = "<group>"; };
+		C4BB0D98256196A300354C08 /* CameraTextureGenerater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraTextureGenerater.swift; sourceTree = "<group>"; };
+		C4BB0D9B256196ED00354C08 /* Texture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Texture.swift; sourceTree = "<group>"; };
+		C4BB0D9F2561983C00354C08 /* SegmentationTextureGenerater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentationTextureGenerater.swift; sourceTree = "<group>"; };
+		C4BB0DA2256199B200354C08 /* OverlayingTexturesGenerater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayingTexturesGenerater.swift; sourceTree = "<group>"; };
+		C4BB0DA525619AA400354C08 /* MetalVideoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetalVideoView.swift; sourceTree = "<group>"; };
+		C4BB0DA825619C0400354C08 /* LiveMetalCameraViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMetalCameraViewController.swift; sourceTree = "<group>"; };
+		C4BB0DB42561A47900354C08 /* Shaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = Shaders.metal; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,11 +91,13 @@
 				71BBE04722E33B2500E74F11 /* Main.storyboard */,
 				71BBE04322E33B2500E74F11 /* AppDelegate.swift */,
 				71BBE04522E33B2500E74F11 /* LiveImageViewController.swift */,
+				C4BB0DA825619C0400354C08 /* LiveMetalCameraViewController.swift */,
 				71BBE05B22E33C6C00E74F11 /* StillImageViewController.swift */,
 				71BBE05E22E33F8D00E74F11 /* DrawingSegmentationView.swift */,
 				71BBE06622E3446300E74F11 /* SegmentationResultMLMultiArray.swift */,
 				71BBE06122E3400E00E74F11 /* Measure.swift */,
 				71BBE06022E3400E00E74F11 /* VideoCapture.swift */,
+				C4BB0D90256192F100354C08 /* MetalCamera */,
 				71BBE05D22E33CEA00E74F11 /* mlmodel */,
 				71BBE04A22E33B2600E74F11 /* Assets.xcassets */,
 				71BBE04C22E33B2600E74F11 /* LaunchScreen.storyboard */,
@@ -94,6 +114,37 @@
 				71BBE05922E33BF300E74F11 /* DeepLabV3Int8LUT.mlmodel */,
 			);
 			path = mlmodel;
+			sourceTree = "<group>";
+		};
+		C4BB0D90256192F100354C08 /* MetalCamera */ = {
+			isa = PBXGroup;
+			children = (
+				C4BB0D91256195AE00354C08 /* MetalRenderingDevice.swift */,
+				C4BB0DA525619AA400354C08 /* MetalVideoView.swift */,
+				C4BB0D98256196A300354C08 /* CameraTextureGenerater.swift */,
+				C4BB0D9F2561983C00354C08 /* SegmentationTextureGenerater.swift */,
+				C4BB0DA2256199B200354C08 /* OverlayingTexturesGenerater.swift */,
+				C4BB0D9B256196ED00354C08 /* Texture.swift */,
+				C4BB0DB32561A46B00354C08 /* Shaders */,
+				C4BB0D94256195E800354C08 /* Utils */,
+			);
+			path = MetalCamera;
+			sourceTree = "<group>";
+		};
+		C4BB0D94256195E800354C08 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				C4BB0D95256195F800354C08 /* Maths.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		C4BB0DB32561A46B00354C08 /* Shaders */ = {
+			isa = PBXGroup;
+			children = (
+				C4BB0DB42561A47900354C08 /* Shaders.metal */,
+			);
+			path = Shaders;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -167,16 +218,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C4BB0DB52561A47900354C08 /* Shaders.metal in Sources */,
+				C4BB0DA3256199B200354C08 /* OverlayingTexturesGenerater.swift in Sources */,
 				71BBE06222E3400E00E74F11 /* VideoCapture.swift in Sources */,
 				71BBE05A22E33BF300E74F11 /* DeepLabV3Int8LUT.mlmodel in Sources */,
 				71BBE06322E3400E00E74F11 /* Measure.swift in Sources */,
+				C4BB0DA625619AA400354C08 /* MetalVideoView.swift in Sources */,
 				71BBE05822E33BEF00E74F11 /* DeepLabV3FP16.mlmodel in Sources */,
 				71BBE06722E3446300E74F11 /* SegmentationResultMLMultiArray.swift in Sources */,
+				C4BB0DA925619C0400354C08 /* LiveMetalCameraViewController.swift in Sources */,
+				C4BB0D9C256196ED00354C08 /* Texture.swift in Sources */,
 				71BBE05622E33BEB00E74F11 /* DeepLabV3.mlmodel in Sources */,
 				71BBE05C22E33C6C00E74F11 /* StillImageViewController.swift in Sources */,
+				C4BB0D96256195F800354C08 /* Maths.swift in Sources */,
+				C4BB0D92256195AE00354C08 /* MetalRenderingDevice.swift in Sources */,
 				71BBE04622E33B2500E74F11 /* LiveImageViewController.swift in Sources */,
+				C4BB0D99256196A300354C08 /* CameraTextureGenerater.swift in Sources */,
 				71BBE05F22E33F8D00E74F11 /* DrawingSegmentationView.swift in Sources */,
 				71BBE04422E33B2500E74F11 /* AppDelegate.swift in Sources */,
+				C4BB0DA02561983C00354C08 /* SegmentationTextureGenerater.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SemanticSegmentation-CoreML/Base.lproj/Main.storyboard
+++ b/SemanticSegmentation-CoreML/Base.lproj/Main.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="OKs-u2-zxf">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="OKs-u2-zxf">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -73,6 +72,7 @@
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="JAF-1N-GU4" firstAttribute="width" secondItem="JAF-1N-GU4" secondAttribute="height" multiplier="3:4" priority="750" id="1jT-Jl-EPl"/>
@@ -86,7 +86,6 @@
                             <constraint firstItem="JAF-1N-GU4" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="mJD-mu-vS6"/>
                             <constraint firstItem="JAF-1N-GU4" firstAttribute="top" secondItem="EeP-4W-fyk" secondAttribute="bottom" id="p7e-cV-nny"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <tabBarItem key="tabBarItem" title="Live Image" id="BjE-eP-ACy"/>
                     <connections>
@@ -99,7 +98,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1047.8260869565217" y="137.94642857142856"/>
+            <point key="canvasLocation" x="1048" y="-510"/>
         </scene>
         <!--Still Image View Controller-->
         <scene sceneID="IS1-oH-MuW">
@@ -121,6 +120,7 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="pfR-pQ-aIK"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="gcq-ZI-Sh1" firstAttribute="width" secondItem="R9C-5j-ZDa" secondAttribute="width" id="7HO-59-VjE"/>
@@ -131,7 +131,6 @@
                             <constraint firstItem="gcq-ZI-Sh1" firstAttribute="centerX" secondItem="R9C-5j-ZDa" secondAttribute="centerX" id="zYu-l7-wc3"/>
                             <constraint firstItem="gcq-ZI-Sh1" firstAttribute="centerY" secondItem="R9C-5j-ZDa" secondAttribute="centerY" id="zkt-y0-Zxs"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="pfR-pQ-aIK"/>
                     </view>
                     <navigationItem key="navigationItem" id="ZKO-r5-lBo">
                         <barButtonItem key="rightBarButtonItem" systemItem="camera" id="WbG-gX-bSA">
@@ -149,16 +148,94 @@
             </objects>
             <point key="canvasLocation" x="1813" y="806"/>
         </scene>
+        <!--GPU Live-->
+        <scene sceneID="5c9-lY-u7Z">
+            <objects>
+                <viewController id="uso-ud-VWq" customClass="LiveMetalCameraViewController" customModule="SemanticSegmentation_CoreML" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="BrB-wO-R8s">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <mtkView contentMode="scaleAspectFit" colorPixelFormat="BGRA8Unorm" depthStencilPixelFormat="Depth32Float" translatesAutoresizingMaskIntoConstraints="NO" id="jI5-DE-WCD" customClass="MetalVideoView" customModule="SemanticSegmentation_CoreML" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="69" width="414" height="744"/>
+                            </mtkView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lCS-RK-DG2">
+                                <rect key="frame" x="0.0" y="44" width="414" height="25"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Inference: xxx ms" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="eCN-te-kgA">
+                                        <rect key="frame" x="16" y="8" width="120.5" height="9"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" name="Courier-Bold" family="Courier" pointSize="9"/>
+                                        <color key="textColor" red="0.0" green="0.98106676339999999" blue="0.57369142770000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Execution: xxx ms" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="m83-Re-i3W">
+                                        <rect key="frame" x="146.5" y="8" width="121" height="9"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" name="Courier-Bold" family="Courier" pointSize="9"/>
+                                        <color key="textColor" red="0.0" green="0.98106676339999999" blue="0.57369142770000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="fps: xx" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="sLS-L3-c6j">
+                                        <rect key="frame" x="277.5" y="8" width="120.5" height="9"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <fontDescription key="fontDescription" name="Courier-Bold" family="Courier" pointSize="9"/>
+                                        <color key="textColor" red="0.0" green="0.98106676339999999" blue="0.57369142770000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.80182470029999997" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="eCN-te-kgA" firstAttribute="top" secondItem="lCS-RK-DG2" secondAttribute="top" constant="8" id="5UN-SY-jbH"/>
+                                    <constraint firstItem="sLS-L3-c6j" firstAttribute="width" secondItem="eCN-te-kgA" secondAttribute="width" id="95R-6u-byv"/>
+                                    <constraint firstItem="m83-Re-i3W" firstAttribute="leading" secondItem="eCN-te-kgA" secondAttribute="trailing" constant="10" id="BId-YR-cBo"/>
+                                    <constraint firstAttribute="bottom" secondItem="eCN-te-kgA" secondAttribute="bottom" constant="8" id="BXN-p5-KoK"/>
+                                    <constraint firstItem="sLS-L3-c6j" firstAttribute="leading" secondItem="m83-Re-i3W" secondAttribute="trailing" constant="10" id="Bop-eV-MSK"/>
+                                    <constraint firstItem="sLS-L3-c6j" firstAttribute="centerY" secondItem="lCS-RK-DG2" secondAttribute="centerY" id="MXH-eB-cwq"/>
+                                    <constraint firstItem="eCN-te-kgA" firstAttribute="centerY" secondItem="lCS-RK-DG2" secondAttribute="centerY" id="Mo0-Rx-dmc"/>
+                                    <constraint firstItem="m83-Re-i3W" firstAttribute="width" secondItem="eCN-te-kgA" secondAttribute="width" id="O7V-sO-IJO"/>
+                                    <constraint firstItem="eCN-te-kgA" firstAttribute="leading" secondItem="lCS-RK-DG2" secondAttribute="leading" constant="16" id="a1R-SY-5ez"/>
+                                    <constraint firstAttribute="trailing" secondItem="sLS-L3-c6j" secondAttribute="trailing" constant="16" id="cDC-01-F57"/>
+                                    <constraint firstItem="m83-Re-i3W" firstAttribute="centerY" secondItem="eCN-te-kgA" secondAttribute="centerY" id="eay-uz-t09"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="ZRo-26-PEe"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="ZRo-26-PEe" firstAttribute="trailing" secondItem="jI5-DE-WCD" secondAttribute="trailing" id="4mM-Rd-x23"/>
+                            <constraint firstItem="jI5-DE-WCD" firstAttribute="leading" secondItem="ZRo-26-PEe" secondAttribute="leading" id="TO8-zS-mBB"/>
+                            <constraint firstItem="lCS-RK-DG2" firstAttribute="leading" secondItem="ZRo-26-PEe" secondAttribute="leading" id="UEj-eA-eVv"/>
+                            <constraint firstItem="ZRo-26-PEe" firstAttribute="bottom" secondItem="jI5-DE-WCD" secondAttribute="bottom" id="ehq-0u-Is5"/>
+                            <constraint firstItem="lCS-RK-DG2" firstAttribute="top" secondItem="ZRo-26-PEe" secondAttribute="top" id="on3-i6-co5"/>
+                            <constraint firstItem="jI5-DE-WCD" firstAttribute="top" secondItem="lCS-RK-DG2" secondAttribute="bottom" id="rEI-by-IkZ"/>
+                            <constraint firstItem="lCS-RK-DG2" firstAttribute="trailing" secondItem="ZRo-26-PEe" secondAttribute="trailing" id="utf-xU-S7a"/>
+                        </constraints>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="GPU Live" id="sPp-wC-0rq"/>
+                    <connections>
+                        <outlet property="etimeLabel" destination="m83-Re-i3W" id="cFc-OO-qCc"/>
+                        <outlet property="fpsLabel" destination="sLS-L3-c6j" id="RHv-qJ-qnz"/>
+                        <outlet property="inferenceLabel" destination="eCN-te-kgA" id="pEQ-QX-SIr"/>
+                        <outlet property="metalVideoPreview" destination="jI5-DE-WCD" id="vOH-hS-bZx"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0a6-Ns-dFL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1047.8260869565217" y="151.33928571428569"/>
+        </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="caK-0V-iKQ">
             <objects>
                 <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="OKs-u2-zxf" sceneMemberID="viewController">
                     <toolbarItems/>
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="k8X-uG-0Ob">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
                     <connections>
+                        <segue destination="uso-ud-VWq" kind="relationship" relationship="viewControllers" id="VPy-Xe-Qw8"/>
                         <segue destination="BYZ-38-t0r" kind="relationship" relationship="viewControllers" id="0lQ-nP-qr8"/>
                         <segue destination="i8C-c5-qYh" kind="relationship" relationship="viewControllers" id="90f-l7-yLE"/>
                     </connections>
@@ -187,4 +264,9 @@
             <point key="canvasLocation" x="1047.8260869565217" y="805.58035714285711"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SemanticSegmentation-CoreML/LiveMetalCameraViewController.swift
+++ b/SemanticSegmentation-CoreML/LiveMetalCameraViewController.swift
@@ -31,22 +31,7 @@ class LiveMetalCameraViewController: UIViewController {
     
     // MARK - Core ML model
     // DeepLabV3(iOS12+), DeepLabV3FP16(iOS12+), DeepLabV3Int8LUT(iOS12+)
-    let segmentationModel = DeepLabV3Int8LUT()
-
-//    11 Pro
-//    DeepLabV3        : 37 465 1
-//    DeepLabV3FP16    : 40 511 1
-//    DeepLabV3Int8LUT : 40 520 1
-//
-//    XS
-//    DeepLabV3        : 135 409 2
-//    DeepLabV3FP16    : 136 403 2
-//    DeepLabV3Int8LUT : 135 412 2
-//
-//    X
-//    DeepLabV3        : 177 531 1
-//    DeepLabV3FP16    : 177 530 1
-//    DeepLabV3Int8LUT : 177 517 1
+    let segmentationModel = DeepLabV3()
     
     // MARK: - Vision Properties
     var request: VNCoreMLRequest?
@@ -109,26 +94,11 @@ class LiveMetalCameraViewController: UIViewController {
         videoCapture.setUp(sessionPreset: .hd1280x720) { success in
             
             if success {
-                // UI에 비디오 미리보기 뷰 넣기
-//                if let previewLayer = self.videoCapture.previewLayer {
-//                    self.videoPreview.layer.addSublayer(previewLayer)
-//                    self.resizePreviewLayer()
-//                }
-                
                 // 초기설정이 끝나면 라이브 비디오를 시작할 수 있음
                 self.videoCapture.start()
             }
         }
     }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        // resizePreviewLayer()
-    }
-    
-//    func resizePreviewLayer() {
-//        videoCapture.previewLayer?.frame = videoPreview.bounds
-//    }
 }
 
 // MARK: - VideoCaptureDelegate
@@ -188,16 +158,6 @@ extension LiveMetalCameraViewController {
                 self?.👨‍🔧.🎬🤚()
                 self?.isInferencing = false
             }
-            
-//            let segmentationResultMLMultiArray = SegmentationResultMLMultiArray(mlMultiArray: segmentationmap)
-//            DispatchQueue.main.async { [weak self] in
-//                // update result
-//                self?.drawingView.segmentationmap = segmentationResultMLMultiArray
-//
-//                // end of measure
-//
-//                self?.isInferencing = false
-//            }
         } else {
             // end of measure
             self.👨‍🔧.🎬🤚()
@@ -218,21 +178,3 @@ extension LiveMetalCameraViewController: 📏Delegate {
         self.fpsLabel.text = "fps: \(self.maf3.averageValue)"
     }
 }
-
-//class MovingAverageFilter {
-//    private var arr: [Int] = []
-//    private let maxCount = 10
-//
-//    public func append(element: Int) {
-//        arr.append(element)
-//        if arr.count > maxCount {
-//            arr.removeFirst()
-//        }
-//    }
-//
-//    public var averageValue: Int {
-//        guard !arr.isEmpty else { return 0 }
-//        let sum = arr.reduce(0) { $0 + $1 }
-//        return Int(Double(sum) / Double(arr.count))
-//    }
-//}

--- a/SemanticSegmentation-CoreML/MetalCamera/CameraTextureGenerater.swift
+++ b/SemanticSegmentation-CoreML/MetalCamera/CameraTextureGenerater.swift
@@ -1,0 +1,47 @@
+//
+//  MetalCamera.swift → CameraTextureGenerater.swift
+//  MetalCamera → SemanticSegmentation-CoreML
+//
+//  Created by Eric on 2020/06/06.
+//  Updated by Doyoung Gwak on 2020/11/16.
+//
+
+import CoreMedia
+
+class CameraTextureGenerater: NSObject {
+    
+    public let sourceKey: String
+    var videoTextureCache: CVMetalTextureCache?
+    
+    public init(sourceKey: String = "camera") {
+        self.sourceKey = sourceKey
+        super.init()
+
+        CVMetalTextureCacheCreate(kCFAllocatorDefault, nil, sharedMetalRenderingDevice.device, nil, &videoTextureCache)
+    }
+    
+    func texture(from sampleBuffer: CMSampleBuffer) -> Texture? {
+        guard let cameraFrame = CMSampleBufferGetImageBuffer(sampleBuffer) else { return nil }
+        guard let videoTextureCache = videoTextureCache else { return nil }
+
+        let bufferWidth = CVPixelBufferGetWidth(cameraFrame)
+        let bufferHeight = CVPixelBufferGetHeight(cameraFrame)
+
+        var textureRef: CVMetalTexture? = nil
+        let _ = CVMetalTextureCacheCreateTextureFromImage(kCFAllocatorDefault,
+                                                          videoTextureCache,
+                                                          cameraFrame,
+                                                          nil,
+                                                          .bgra8Unorm,
+                                                          bufferWidth,
+                                                          bufferHeight,
+                                                          0,
+                                                          &textureRef)
+        if let concreteTexture = textureRef,
+            let cameraTexture = CVMetalTextureGetTexture(concreteTexture) {
+            return Texture(texture: cameraTexture, textureKey: self.sourceKey)
+        } else {
+            return nil
+        }
+    }
+}

--- a/SemanticSegmentation-CoreML/MetalCamera/MetalRenderingDevice.swift
+++ b/SemanticSegmentation-CoreML/MetalCamera/MetalRenderingDevice.swift
@@ -1,0 +1,61 @@
+//
+//  MetalRenderingDevice.swift
+//  MetalCamera
+//
+//  Created by Eric on 2020/06/04.
+//
+
+import CoreGraphics
+import Metal
+
+public let sharedMetalRenderingDevice = MetalRenderingDevice()
+
+public class MetalRenderingDevice {
+    public let device: MTLDevice
+    public let commandQueue: MTLCommandQueue
+
+    init() {
+        guard let device = MTLCreateSystemDefaultDevice() else { fatalError("Could not create Metal Device") }
+        self.device = device
+
+        guard let queue = self.device.makeCommandQueue() else { fatalError("Could not create command queue") }
+        self.commandQueue = queue
+    }
+
+    func generateRenderPipelineDescriptor(_ vertexFuncName: String, _ fragmentFuncName: String, _ colorPixelFormat: MTLPixelFormat = .bgra8Unorm) throws -> MTLRenderPipelineDescriptor {
+        let framework = Bundle.main
+        let resource = framework.path(forResource: "default", ofType: "metallib")!
+        let library = try self.device.makeLibrary(filepath: resource)
+
+        let vertex_func = library.makeFunction(name: vertexFuncName)
+        let fragment_func = library.makeFunction(name: fragmentFuncName)
+        let rpd = MTLRenderPipelineDescriptor()
+        rpd.vertexFunction = vertex_func
+        rpd.fragmentFunction = fragment_func
+        rpd.colorAttachments[0].pixelFormat = colorPixelFormat
+
+        return rpd
+    }
+
+    func makeRenderVertexBuffer(_ origin: CGPoint = .zero, size: CGSize) -> MTLBuffer? {
+        let w = size.width, h = size.height
+        let vertices = [
+            Vertex(position: CGPoint(x: origin.x , y: origin.y), textCoord: CGPoint(x: 0, y: 0)),
+            Vertex(position: CGPoint(x: origin.x + w , y: origin.y), textCoord: CGPoint(x: 1, y: 0)),
+            Vertex(position: CGPoint(x: origin.x + 0 , y: origin.y + h), textCoord: CGPoint(x: 0, y: 1)),
+            Vertex(position: CGPoint(x: origin.x + w , y: origin.y + h), textCoord: CGPoint(x: 1, y: 1)),
+        ]
+        return makeRenderVertexBuffer(vertices)
+    }
+
+    func makeRenderVertexBuffer(_ vertices: [Vertex]) -> MTLBuffer? {
+        return self.device.makeBuffer(bytes: vertices, length: MemoryLayout<Vertex>.stride * vertices.count, options: .cpuCacheModeWriteCombined)
+    }
+
+    func makeRenderUniformBuffer(_ size: CGSize) -> MTLBuffer? {
+        let metrix = Matrix.identity
+        metrix.scaling(x: 2 / Float(size.width), y: -2 / Float(size.height), z: 1)
+        metrix.translation(x: -1, y: 1, z: 0)
+        return self.device.makeBuffer(bytes: metrix.m, length: MemoryLayout<Float>.size * 16, options: [])
+    }
+}

--- a/SemanticSegmentation-CoreML/MetalCamera/MetalVideoView.swift
+++ b/SemanticSegmentation-CoreML/MetalCamera/MetalVideoView.swift
@@ -1,0 +1,79 @@
+//
+//  MetalVideoView.swift
+//  MetalCamera
+//
+//  Created by Eric on 2020/06/04.
+//
+
+import Foundation
+import MetalKit
+
+public class MetalVideoView: MTKView {
+    public var currentTexture: Texture? {
+        willSet (newValue) {
+            guard let texture = newValue else { return }
+            drawableSize = CGSize(width: texture.texture.width, height: texture.texture.height)
+        }
+    }
+
+    private var pipelineState: MTLRenderPipelineState!
+    private var render_target_vertex: MTLBuffer!
+    private var render_target_uniform: MTLBuffer!
+
+    public required init(coder: NSCoder) {
+        super.init(coder: coder)
+
+        setup()
+    }
+
+    private func setup() {
+        self.device = sharedMetalRenderingDevice.device
+
+        isOpaque = false
+        setupTargetUniforms()
+
+        do {
+            try setupPiplineState()
+        } catch {
+            fatalError("Metal initialize failed: \(error.localizedDescription)")
+        }
+    }
+
+    func setupTargetUniforms() {
+        let size = drawableSize
+        render_target_vertex = sharedMetalRenderingDevice.makeRenderVertexBuffer(size: size)
+        render_target_uniform = sharedMetalRenderingDevice.makeRenderUniformBuffer(size)
+    }
+
+    private func setupPiplineState() throws {
+        let rpd = try sharedMetalRenderingDevice.generateRenderPipelineDescriptor("vertex_render_target",
+                                                                                  "fragment_render_target",
+                                                                                  colorPixelFormat)
+        pipelineState = try sharedMetalRenderingDevice.device.makeRenderPipelineState(descriptor: rpd)
+    }
+
+    public override func draw(_ rect:CGRect) {
+        if let currentDrawable = self.currentDrawable, let imageTexture = currentTexture {
+            let renderPassDescriptor = MTLRenderPassDescriptor()
+            let attachment = renderPassDescriptor.colorAttachments[0]
+            attachment?.clearColor = clearColor
+            attachment?.texture = currentDrawable.texture
+            attachment?.loadAction = .clear
+            attachment?.storeAction = .store
+
+            let commandBuffer = sharedMetalRenderingDevice.commandQueue.makeCommandBuffer()
+            let commandEncoder = commandBuffer?.makeRenderCommandEncoder(descriptor: renderPassDescriptor)
+
+            commandEncoder?.setRenderPipelineState(pipelineState)
+
+            commandEncoder?.setVertexBuffer(render_target_vertex, offset: 0, index: 0)
+            commandEncoder?.setVertexBuffer(render_target_uniform, offset: 0, index: 1)
+            commandEncoder?.setFragmentTexture(imageTexture.texture, index: 0)
+            commandEncoder?.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+
+            commandEncoder?.endEncoding()
+            commandBuffer?.present(currentDrawable)
+            commandBuffer?.commit()
+        }
+    }
+}

--- a/SemanticSegmentation-CoreML/MetalCamera/OverlayingTexturesGenerater.swift
+++ b/SemanticSegmentation-CoreML/MetalCamera/OverlayingTexturesGenerater.swift
@@ -1,0 +1,120 @@
+//
+//  OverlayingTexturesGenerater.swift
+//  SemanticSegmentation-CoreML
+//
+//  Created by Eric on 2020/06/06.
+//  Copyright © 2020 Eric. All rights reserved.
+//
+
+import MetalKit
+
+public let standardImageVertices: [Float] = [-1.0, 1.0, 1.0, 1.0, -1.0, -1.0, 1.0, -1.0]
+public let standardTextureCoordinate: [Float] = [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0]
+
+class OverlayingTexturesGenerater: NSObject {
+    
+    private var pipelineState: MTLRenderPipelineState!
+    
+    private var textureBuffer1: MTLBuffer?
+    private var textureBuffer2: MTLBuffer?
+    
+    public var alphaValue: Float = 0.5
+    
+    public override init() {
+        super.init()
+        setup()
+    }
+
+    private func setup() {
+        setupPiplineState()
+    }
+
+    private func setupPiplineState(_ colorPixelFormat: MTLPixelFormat = .bgra8Unorm) {
+        do {
+            let rpd = try sharedMetalRenderingDevice.generateRenderPipelineDescriptor("two_vertex_render_target",
+                                                                                      "alphaBlendFragment",
+                                                                                      colorPixelFormat)
+            pipelineState = try sharedMetalRenderingDevice.device.makeRenderPipelineState(descriptor: rpd)
+        } catch {
+            debugPrint(error)
+        }
+    }
+    
+    private func generateTextureBuffer(_ width: Int, _ height: Int, _ targetWidth: Int, _ targetHeight: Int) -> MTLBuffer? {
+        let targetRatio = Float(targetWidth)/Float(targetHeight)
+        let curRatio = Float(width)/Float(height)
+
+        let coordinates: [Float]
+
+        if targetRatio > curRatio {
+            let remainHeight = (Float(height) - Float(width) * targetRatio)/2.0
+            let remainRatio = remainHeight/Float(height)
+            coordinates = [0.0, remainRatio, 1.0, remainRatio, 0.0, 1.0 - remainRatio, 1.0, 1.0 - remainRatio]
+        } else {
+            let remainWidth = (Float(width) - Float(height) * targetRatio)/2.0
+            let remainRatio = remainWidth/Float(width)
+            coordinates = [remainRatio, 0.0, 1.0 - remainRatio, 0.0, remainRatio, 1.0, 1.0 - remainRatio, 1.0]
+        }
+
+        let textureBuffer = sharedMetalRenderingDevice.device.makeBuffer(bytes: coordinates,
+                                                                         length: coordinates.count * MemoryLayout<Float>.size,
+                                                                         options: [])!
+        return textureBuffer
+    }
+    
+    func texture(_ source1: Texture, _ source2: Texture) -> Texture? {
+        let minX = min(source1.texture.width, source2.texture.width)
+        let minY = min(source1.texture.height, source2.texture.height)
+        
+        // 버퍼 준비
+        if textureBuffer1 == nil {
+            textureBuffer1 = generateTextureBuffer(source1.texture.width, source1.texture.height, minX, minY)
+        }
+        if textureBuffer2 == nil {
+            textureBuffer2 = generateTextureBuffer(source2.texture.width, source2.texture.height, minX, minY)
+        }
+
+        let outputTexture = Texture(minX, minY, textureKey: source1.textureKey)
+
+        let renderPassDescriptor = MTLRenderPassDescriptor()
+        let attachment = renderPassDescriptor.colorAttachments[0]
+        attachment?.clearColor = MTLClearColorMake(1, 0, 0, 1)
+        attachment?.texture = outputTexture.texture
+        attachment?.loadAction = .clear
+        attachment?.storeAction = .store
+        
+        // command buffer 준비
+        let commandBuffer = sharedMetalRenderingDevice.commandQueue.makeCommandBuffer()
+        // command encoder 생성
+        let commandEncoder = commandBuffer?.makeRenderCommandEncoder(descriptor: renderPassDescriptor)
+
+        commandEncoder?.setFrontFacing(.counterClockwise)
+        commandEncoder?.setRenderPipelineState(pipelineState)
+        
+        // vertex buffer 준비
+        let vertexBuffer = sharedMetalRenderingDevice.device.makeBuffer(bytes: standardImageVertices,
+                                                                        length: standardImageVertices.count * MemoryLayout<Float>.size,
+                                                                        options: [])!
+        vertexBuffer.label = "Vertices"
+        commandEncoder?.setVertexBuffer(vertexBuffer, offset: 0, index: 0)
+        commandEncoder?.setVertexBuffer(textureBuffer1, offset: 0, index: 1)
+        commandEncoder?.setVertexBuffer(textureBuffer2, offset: 0, index: 2)
+
+        // fragment texture, buffer 준비
+        commandEncoder?.setFragmentTexture(source1.texture, index: 0)
+        commandEncoder?.setFragmentTexture(source2.texture, index: 1)
+        let uniformBuffer = sharedMetalRenderingDevice.device.makeBuffer(bytes: [alphaValue],
+                                                                         length: 1 * MemoryLayout<Float>.size,
+                                                                         options: [])!
+        commandEncoder?.setFragmentBuffer(uniformBuffer, offset: 0, index: 1)
+        
+        // privitive 설정
+        commandEncoder?.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        // command encoder 끝
+        commandEncoder?.endEncoding()
+        // 실행
+        commandBuffer?.commit()
+        
+        return outputTexture
+    }
+}

--- a/SemanticSegmentation-CoreML/MetalCamera/SegmentationTextureGenerater.swift
+++ b/SemanticSegmentation-CoreML/MetalCamera/SegmentationTextureGenerater.swift
@@ -1,0 +1,70 @@
+//
+//  AlphaBlend.swift → SegmentationTextureGenerater.swift
+//  MetalCamera → SemanticSegmentation-CoreML
+//
+//  Created by Eric on 2020/06/16.
+//  Updated by Doyoung Gwak on 2020/11/16.
+//
+
+import MetalKit
+import CoreML
+
+class SegmentationTextureGenerater: NSObject {
+    
+    private var pipelineState: MTLRenderPipelineState!
+    private var render_target_vertex: MTLBuffer!
+    private var render_target_uniform: MTLBuffer!
+    
+    private func setupPiplineState(_ colorPixelFormat: MTLPixelFormat = .bgra8Unorm, width: Int, height: Int) {
+        do {
+            let rpd = try sharedMetalRenderingDevice.generateRenderPipelineDescriptor("vertex_render_target",
+                                                                                      "segmentation_render_target",
+                                                                                      colorPixelFormat)
+            pipelineState = try sharedMetalRenderingDevice.device.makeRenderPipelineState(descriptor: rpd)
+
+            render_target_vertex = sharedMetalRenderingDevice.makeRenderVertexBuffer(size: CGSize(width: width, height: height))
+            render_target_uniform = sharedMetalRenderingDevice.makeRenderUniformBuffer(CGSize(width: width, height: height))
+        } catch {
+            debugPrint(error)
+        }
+    }
+    
+    func texture(_ segmentationMap: MLMultiArray, _ row: Int, _ col: Int, _ targetClass: Int) -> Texture? {
+        if pipelineState == nil {
+            setupPiplineState(width: col, height: row)
+        }
+
+        let outputTexture = Texture(col, row, textureKey: "segmentation")
+
+        let renderPassDescriptor = MTLRenderPassDescriptor()
+        let attachment = renderPassDescriptor.colorAttachments[0]
+        attachment?.clearColor = MTLClearColorMake(1, 0, 0, 1)
+        attachment?.texture = outputTexture.texture
+        attachment?.loadAction = .clear
+        attachment?.storeAction = .store
+
+        let commandBuffer = sharedMetalRenderingDevice.commandQueue.makeCommandBuffer()
+        let commandEncoder = commandBuffer?.makeRenderCommandEncoder(descriptor: renderPassDescriptor)
+
+        commandEncoder?.setRenderPipelineState(pipelineState)
+
+        commandEncoder?.setVertexBuffer(render_target_vertex, offset: 0, index: 0)
+        commandEncoder?.setVertexBuffer(render_target_uniform, offset: 0, index: 1)
+
+        let segmentationBuffer = sharedMetalRenderingDevice.device.makeBuffer(bytes: segmentationMap.dataPointer,
+                                                                              length: segmentationMap.count * MemoryLayout<Int32>.size,
+                                                                              options: [])!
+        commandEncoder?.setFragmentBuffer(segmentationBuffer, offset: 0, index: 0)
+
+        let uniformBuffer = sharedMetalRenderingDevice.device.makeBuffer(bytes: [Int32(targetClass), Int32(col), Int32(row)] as [Int32],
+                                                                         length: 3 * MemoryLayout<Int32>.size,
+                                                                         options: [])!
+        commandEncoder?.setFragmentBuffer(uniformBuffer, offset: 0, index: 1)
+
+        commandEncoder?.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+        commandEncoder?.endEncoding()
+        commandBuffer?.commit()
+
+        return outputTexture
+    }
+}

--- a/SemanticSegmentation-CoreML/MetalCamera/SegmentationTextureGenerater.swift
+++ b/SemanticSegmentation-CoreML/MetalCamera/SegmentationTextureGenerater.swift
@@ -38,7 +38,7 @@ class SegmentationTextureGenerater: NSObject {
 
         let renderPassDescriptor = MTLRenderPassDescriptor()
         let attachment = renderPassDescriptor.colorAttachments[0]
-        attachment?.clearColor = MTLClearColorMake(1, 0, 0, 1)
+        attachment?.clearColor = MTLClearColorMake(1, 0, 0, 1) // r, g, b, a
         attachment?.texture = outputTexture.texture
         attachment?.loadAction = .clear
         attachment?.storeAction = .store

--- a/SemanticSegmentation-CoreML/MetalCamera/Shaders/Shaders.metal
+++ b/SemanticSegmentation-CoreML/MetalCamera/Shaders/Shaders.metal
@@ -1,0 +1,151 @@
+#include <metal_stdlib>
+using namespace metal;
+
+struct Vertex {
+    float4 position [[position]];
+    float2 text_coord;
+};
+
+struct TwoInputVertex
+{
+    float4 position [[position]];
+    float2 textureCoordinate [[user(texturecoord)]];
+    float2 textureCoordinate2 [[user(texturecoord2)]];
+};
+
+struct Uniforms {
+    float4x4 scaleMatrix;
+};
+
+vertex Vertex vertex_render_target(constant Vertex *vertexes [[ buffer(0) ]],
+                                   constant Uniforms &uniforms [[ buffer(1) ]],
+                                   uint vid [[vertex_id]])
+{
+    Vertex out = vertexes[vid];
+    out.position = uniforms.scaleMatrix * out.position;// * in.position;
+    return out;
+};
+
+vertex TwoInputVertex two_vertex_render_target(const device packed_float2 *position [[buffer(0)]],
+                                               const device packed_float2 *texturecoord [[buffer(1)]],
+                                               const device packed_float2 *texturecoord2 [[buffer(2)]],
+                                               uint vid [[vertex_id]]) {
+    TwoInputVertex outputVertices;
+    outputVertices.position = float4(position[vid], 0, 1.0);
+    outputVertices.textureCoordinate = texturecoord[vid];
+    outputVertices.textureCoordinate2 = texturecoord2[vid];
+    return outputVertices;
+};
+
+
+fragment float4 fragment_render_target(Vertex vertex_data [[ stage_in ]],
+                                       texture2d<float> tex2d [[ texture(0) ]])
+{
+    constexpr sampler textureSampler(mag_filter::linear, min_filter::linear);
+    float4 color = float4(tex2d.sample(textureSampler, vertex_data.text_coord));
+    return color;
+};
+
+fragment float4 gray_fragment_render_target(Vertex vertex_data [[ stage_in ]],
+                                            texture2d<float> tex2d [[ texture(0) ]])
+{
+    constexpr sampler textureSampler(mag_filter::linear, min_filter::linear);
+    float4 color = float4(tex2d.sample(textureSampler, vertex_data.text_coord));
+    float gray = (color[0] + color[1] + color[2])/3;
+    return float4(gray, gray, gray, 1.0);
+};
+
+typedef struct
+{
+    float mixturePercent;
+} AlphaBlendUniform;
+
+fragment half4 alphaBlendFragment(TwoInputVertex fragmentInput [[stage_in]],
+                                  texture2d<half> inputTexture [[texture(0)]],
+                                  texture2d<half> inputTexture2 [[texture(1)]],
+                                  constant AlphaBlendUniform& uniform [[ buffer(1) ]])
+{
+    constexpr sampler quadSampler;
+    half4 textureColor = inputTexture.sample(quadSampler, fragmentInput.textureCoordinate);
+    constexpr sampler quadSampler2;
+    half4 textureColor2 = inputTexture2.sample(quadSampler, fragmentInput.textureCoordinate2);
+
+    return half4(mix(textureColor.rgb, textureColor2.rgb, textureColor2.a * half(uniform.mixturePercent)), textureColor.a);
+}
+
+fragment half4 maskFragment(TwoInputVertex fragmentInput [[stage_in]],
+                            texture2d<half> inputTexture [[texture(0)]],
+                            texture2d<half> inputTexture2 [[texture(1)]])
+{
+    constexpr sampler quadSampler;
+    half4 textureColor = inputTexture.sample(quadSampler, fragmentInput.textureCoordinate);
+    constexpr sampler quadSampler2;
+    half4 textureColor2 = inputTexture2.sample(quadSampler, fragmentInput.textureCoordinate2);
+
+    if(textureColor2.r + textureColor2.g + textureColor2.b > 0) {
+        return textureColor;
+    } else {
+        return half4(0, 0, 0 ,0);
+    }
+}
+
+typedef struct
+{
+    int32_t classNum;
+} SegmentationValue;
+
+typedef struct
+{
+    int32_t targetClass;
+    int32_t width;
+    int32_t height;
+} SegmentationUniform;
+
+fragment float4 segmentation_render_target(Vertex vertex_data [[ stage_in ]],
+                                           constant SegmentationValue *segmentation [[ buffer(0) ]],
+                                           constant SegmentationUniform& uniform [[ buffer(1) ]])
+
+{
+    int index = int(vertex_data.position.x) + int(vertex_data.position.y) * uniform.width;
+    if(segmentation[index].classNum == uniform.targetClass) {
+        return float4(1.0, 0, 0, 1.0);
+    }
+
+    return float4(0,0,0,1.0);
+};
+
+fragment half4 lookupFragment(TwoInputVertex fragmentInput [[stage_in]],
+                              texture2d<half> inputTexture [[texture(0)]],
+                              texture2d<half> inputTexture2 [[texture(1)]],
+                              constant float& intensity [[ buffer(1) ]])
+{
+    constexpr sampler quadSampler;
+    half4 base = inputTexture.sample(quadSampler, fragmentInput.textureCoordinate);
+
+    half blueColor = base.b * 63.0h;
+
+    half2 quad1;
+    quad1.y = floor(floor(blueColor) / 8.0h);
+    quad1.x = floor(blueColor) - (quad1.y * 8.0h);
+
+    half2 quad2;
+    quad2.y = floor(ceil(blueColor) / 8.0h);
+    quad2.x = ceil(blueColor) - (quad2.y * 8.0h);
+
+    float2 texPos1;
+    texPos1.x = (quad1.x * 0.125) + 0.5/512.0 + ((0.125 - 1.0/512.0) * base.r);
+    texPos1.y = (quad1.y * 0.125) + 0.5/512.0 + ((0.125 - 1.0/512.0) * base.g);
+
+    float2 texPos2;
+    texPos2.x = (quad2.x * 0.125) + 0.5/512.0 + ((0.125 - 1.0/512.0) * base.r);
+    texPos2.y = (quad2.y * 0.125) + 0.5/512.0 + ((0.125 - 1.0/512.0) * base.g);
+
+    constexpr sampler quadSampler3;
+    half4 newColor1 = inputTexture2.sample(quadSampler3, texPos1);
+    constexpr sampler quadSampler4;
+    half4 newColor2 = inputTexture2.sample(quadSampler4, texPos2);
+
+    half4 newColor = mix(newColor1, newColor2, fract(blueColor));
+
+    return half4(mix(base, half4(newColor.rgb, base.w), half(intensity)));
+}

--- a/SemanticSegmentation-CoreML/MetalCamera/Texture.swift
+++ b/SemanticSegmentation-CoreML/MetalCamera/Texture.swift
@@ -1,0 +1,34 @@
+//
+//  Texture.swift
+//  MetalCamera
+//
+//  Created by Eric on 2020/06/06.
+//
+
+import Foundation
+import AVFoundation
+
+public class Texture {
+    let texture: MTLTexture
+    let textureKey: String
+
+    public init(texture: MTLTexture, textureKey: String = "") {
+        self.texture = texture
+        self.textureKey = textureKey
+    }
+
+    public init(_ width: Int, _ height: Int, pixelFormat: MTLPixelFormat = .bgra8Unorm, textureKey: String = "") {
+        let textureDescriptor = MTLTextureDescriptor.texture2DDescriptor(pixelFormat: .bgra8Unorm,
+                                                                         width: width,
+                                                                         height: height,
+                                                                         mipmapped: false)
+        textureDescriptor.usage = [.renderTarget, .shaderRead, .shaderWrite]
+
+        guard let newTexture = sharedMetalRenderingDevice.device.makeTexture(descriptor: textureDescriptor) else {
+            fatalError("Could not create texture of size: (\(width), \(height))")
+        }
+
+        self.texture = newTexture
+        self.textureKey = textureKey
+    }
+}

--- a/SemanticSegmentation-CoreML/MetalCamera/Utils/Maths.swift
+++ b/SemanticSegmentation-CoreML/MetalCamera/Utils/Maths.swift
@@ -1,0 +1,166 @@
+//
+//  Maths.swift
+//  MetalRecorder
+//
+//  Created by Eric on 2020/05/30.
+//  Copyright © 2020 Eric. All rights reserved.
+//
+
+import Foundation
+import CoreGraphics
+import simd
+
+struct Vertex {
+    var position: vector_float4
+    var textCoord: vector_float2
+
+    init(position: CGPoint, textCoord: CGPoint) {
+        self.position = position.toFloat4()
+        self.textCoord = textCoord.toFloat2()
+    }
+}
+
+struct Uniforms {
+    var scaleMatrix: [Float]
+    init(scale: Float = 1, drawableSize: CGSize) {
+        scaleMatrix = Matrix.identity.scaling(x:  0.5,  y: 0.5, z: 1).m
+    }
+}
+
+class Matrix {
+
+    private(set) var m: [Float]
+
+    static var identity = Matrix()
+
+    private init() {
+        m = [1, 0, 0, 0,
+             0, 1, 0, 0,
+             0, 0, 1, 0,
+             0, 0, 0, 1
+        ]
+    }
+
+    @discardableResult
+    func translation(x: Float, y: Float, z: Float) -> Matrix {
+        m[12] = x
+        m[13] = y
+        m[14] = z
+        return self
+    }
+
+    @discardableResult
+    func scaling(x: Float, y: Float, z: Float)  -> Matrix  {
+        m[0] = x
+        m[5] = y
+        m[10] = z
+        return self
+    }
+}
+
+// MARK: - Point Utils
+extension CGPoint {
+
+    static func middle(p1: CGPoint, p2: CGPoint) -> CGPoint {
+        return CGPoint(x: (p1.x + p2.x) * 0.5, y: (p1.y + p2.y) * 0.5)
+    }
+
+    func distance(to other: CGPoint) -> CGFloat {
+        let p = pow(x - other.x, 2) + pow(y - other.y, 2)
+        return sqrt(p)
+    }
+
+    func angel(to other: CGPoint = .zero) -> CGFloat {
+        let point = self - other
+        if y == 0 {
+            return x >= 0 ? 0 : CGFloat.pi
+        }
+        return -CGFloat(atan2f(Float(point.y), Float(point.x)))
+    }
+
+    func toFloat4(z: CGFloat = 0, w: CGFloat = 1) -> vector_float4 {
+        return [Float(x), Float(y), Float(z) ,Float(w)]
+    }
+
+    func toFloat2() -> vector_float2 {
+        return [Float(x), Float(y)]
+    }
+
+    func offsetedBy(x: CGFloat = 0, y: CGFloat = 0) -> CGPoint {
+        var point = self
+        point.x += x
+        point.y += y
+        return point
+    }
+
+    func rotatedBy(_ angle: CGFloat, anchor: CGPoint) -> CGPoint {
+        let point = self - anchor
+        let a = Double(-angle)
+        let x = Double(point.x)
+        let y = Double(point.y)
+        let x_ = x * cos(a) - y * sin(a);
+        let y_ = x * sin(a) + y * cos(a);
+        return CGPoint(x: CGFloat(x_), y: CGFloat(y_)) + anchor
+    }
+}
+
+func +(lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+    return CGPoint(x: lhs.x + rhs.x, y: lhs.y + rhs.y)
+}
+
+func +=(lhs: inout CGPoint, rhs: CGPoint) {
+    lhs = lhs + rhs
+}
+
+func -(lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+    return CGPoint(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
+}
+
+func *(lhs: CGPoint, rhs: CGFloat) -> CGPoint {
+    return CGPoint(x: lhs.x * rhs, y: lhs.y * rhs)
+}
+
+func /(lhs: CGPoint, rhs: CGFloat) -> CGPoint {
+    return CGPoint(x: lhs.x / rhs, y: lhs.y / rhs)
+}
+
+func +(lhs: CGSize, rhs: CGSize) -> CGSize {
+    return CGSize(width: lhs.width + rhs.width, height: lhs.height + rhs.height)
+}
+
+func *(lhs: CGSize, rhs: CGFloat) -> CGSize {
+    return CGSize(width: lhs.width * rhs, height: lhs.height * rhs)
+}
+
+func /(lhs: CGSize, rhs: CGFloat) -> CGSize {
+    return CGSize(width: lhs.width / rhs, height: lhs.height / rhs)
+}
+
+func +(lhs: CGPoint, rhs: CGSize) -> CGPoint {
+    return CGPoint(x: lhs.x + rhs.width, y: lhs.y + rhs.height)
+}
+
+func -(lhs: CGPoint, rhs: CGSize) -> CGPoint {
+    return CGPoint(x: lhs.x - rhs.width, y: lhs.y - rhs.height)
+}
+
+func *(lhs: CGPoint, rhs: CGSize) -> CGPoint {
+    return CGPoint(x: lhs.x * rhs.width, y: lhs.y * rhs.height)
+}
+
+func /(lhs: CGPoint, rhs: CGSize) -> CGPoint {
+    return CGPoint(x: lhs.x / rhs.width, y: lhs.y / rhs.height)
+}
+
+
+extension Comparable {
+    func valueBetween(min: Self, max: Self) -> Self {
+        if self > max {
+            return max
+        } else if self < min {
+            return min
+        }
+        return self
+    }
+}
+


### PR DESCRIPTION
> Super thanks @jsharp83 for your [MetalCamera](https://github.com/jsharp83/MetalCamera)

![segmentation-gpu-demo-001](https://user-images.githubusercontent.com/37643248/99242802-167ad280-2843-11eb-959a-5fe3b169d8f0.gif)

## Related Issue

- #5 

## Changed

- Make post-processing on real-time segmentation extremely fast 
  - AS-IS(CPU): `> 240 ms` (iPhone 11 Pro)
  - TO-BE(GPU): `< 1 ms` (iPhone 11 Pro)
- The main logic during generating textures:
  1. Get current pixelbuffer from camera
  2. Inference the pixelbuffer and get a segmentation map
  3. Generate a texture from the pixelbuffer (`cameraTexture`) https://github.com/tucan9389/SemanticSegmentation-CoreML/pull/7#discussion_r524046755
  4. Generate a texture from the segmentation map (`segmentaitonTexture`) https://github.com/tucan9389/SemanticSegmentation-CoreML/pull/7#discussion_r524047448
  5. Merge the textures and make a texture (`overlayedTexture`) https://github.com/tucan9389/SemanticSegmentation-CoreML/pull/7#discussion_r524047448
  6. Assign the `overlayedTexture` to `metalVideoPreview: MetalVideoView`
  7. Draw the `overlayedTexture` texture

## PR Points

- Add `LiveMetalCameraViewController` post-processing with [MetalKit](https://developer.apple.com/documentation/metalkit/)
- Support extremely fast post-process
  - Add `MetalRenderingDevice.swift` from MetalCamera
  - Add `MetalVideoView.swift` from MetalCamera
  - Add `CameraTextureGenerater.swift` from MetalCamera
  - Add `SegmentationTextureGenerater.swift` from MetalCamera
  - Add `OverlayingTexturesGenerater.swift` from MetalCamera
  - Add other utils and shader code from MetalCamera

## Reference

- https://github.com/jsharp83/MetalCamera
- https://github.com/jsharp83/MetalCamera/blob/master/Example/MetalCamera/SegmentationSampleViewController.swift